### PR TITLE
Dev

### DIFF
--- a/dival/version.py
+++ b/dival/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.3.7'
+__version__ = '0.4.0'


### PR DESCRIPTION
version 0.4.0
breaking changes to `'ellipses'` standard dataset from commit [e2b4066](https://github.com/jleuschn/dival/commit/e2b406678d395eaa61d4df94df830c2c369a4571):
* use zero background
* change ellipses generation settings (intensity, number of ellipses, etc.)
* remove parameter to normalize by operator norm (you now need to normalize the observations manually if you wish to do so. This however makes the dataset more simple.)