### PR TITLE
reuse iterates in TaskTable.run, add StandardIterativeReconstructor, …

### DIFF
--- a/dival/version.py
+++ b/dival/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/test/test_reconstructor.py
+++ b/test/test_reconstructor.py
@@ -7,6 +7,7 @@ import odl
 from odl.solvers.util.callback import CallbackApply, CallbackStore
 from odl.operator.default_ops import ScalingOperator
 from dival.reconstructors.reconstructor import (Reconstructor,
+                                                StandardIterativeReconstructor,
                                                 FunctionReconstructor)
 from dival.reconstructors.odl_reconstructors import LandweberReconstructor
 
@@ -98,7 +99,63 @@ class TestReconstructor(unittest.TestCase):
         self.assertDictEqual(r.hyper_params, json.loads(ext['str']))
 
 
-class TestIterativeReconstructor(unittest.TestCase):
+class TestStandardIterativeReconstructor(unittest.TestCase):
+    def test_reconstruct(self):
+        domain = odl.uniform_discr([0, 0], [1, 1], (1, 1))
+        observation = domain.one()
+
+        # reconstruct 1., iterates 0., 0.5, 0.75, 0.875, ...
+
+        class DummyReconstructor(StandardIterativeReconstructor):
+            def _setup(self, observation):
+                self.setup_var = 'dummy_val'
+
+            def _compute_iterate(self, observation, reco_previous, out):
+                out[:] = 0.5 * (observation + reco_previous)
+
+        r = DummyReconstructor(reco_space=domain,
+                               hyper_params={'iterations': 100})
+        reco = r.reconstruct(observation)
+        self.assertAlmostEqual(reco.asarray(), observation.asarray(),
+                               delta=1e-7)
+
+        r2 = DummyReconstructor(reco_space=domain,
+                                hyper_params={'iterations': 2})
+        reco2 = r2.reconstruct(observation)
+        self.assertNotAlmostEqual(reco2.asarray(), observation.asarray(),
+                                  delta=0.2)
+
+        # test init values
+
+        r3 = DummyReconstructor(reco_space=domain,
+                                hyper_params={'iterations': 2},
+                                x0=domain.element(0.5))
+        reco3 = r3.reconstruct(observation)
+        self.assertAlmostEqual(reco3.asarray(), observation.asarray(),
+                               delta=0.2)
+
+        r4 = DummyReconstructor(reco_space=domain,
+                                hyper_params={'iterations': 2},
+                                x0=domain.zero())
+        reco4 = r4.reconstruct(observation, x0=domain.element(0.5))
+        self.assertAlmostEqual(reco4.asarray(), observation.asarray(),
+                               delta=0.2)
+
+        r5 = DummyReconstructor(reco_space=domain,
+                                hyper_params={'iterations': 2})
+        reco5 = domain.element(0.5)
+        r5.reconstruct(observation, out=reco5)
+        self.assertAlmostEqual(reco5.asarray(), observation.asarray(),
+                               delta=0.2)
+
+        r6 = DummyReconstructor(reco_space=domain,
+                                hyper_params={'iterations': 2},
+                                x0=domain.zero())
+        reco6 = domain.element(0.5)
+        r6.reconstruct(observation, out=reco6)
+        self.assertNotAlmostEqual(reco6.asarray(), observation.asarray(),
+                                  delta=0.2)
+
     def test_callback_assignment(self):
         domain = odl.uniform_discr([0, 0], [1, 1], (1, 1))
         op = ScalingOperator(domain, 0.5)
@@ -109,17 +166,17 @@ class TestIterativeReconstructor(unittest.TestCase):
         self.assertEqual(r.callback, callback)
         callback2 = CallbackApply(lambda x: 1.)
         r.reconstruct(domain.one(), callback=callback2)
-        self.assertEqual(r.callback, callback2)
+        self.assertEqual(r.callback, callback)
 
     def test_callback(self):
         domain = odl.uniform_discr([0, 0], [1, 1], (1, 1))
         op = ScalingOperator(domain, 0.5)
         niter = 7
-        result = []
-        callback = CallbackStore(result)
+        iters = []
+        callback = CallbackStore(iters)
         r = LandweberReconstructor(op, domain.one(), niter, callback=callback)
         r.reconstruct(domain.one())
-        self.assertEqual(len(result), niter)
+        self.assertEqual(len(iters), niter)
 
 
 class TestFunctionReconstructor(unittest.TestCase):


### PR DESCRIPTION
- Reuse iterates in `TaskTable.run` if `hyper_param_choices` contains choices that differ only in the number of iterations of an `IterativeReconstructor`.
- Add `StandardIterativeReconstructor`.
- Fix for `save_iterates` and `save_iterates_measure_values` that did not use `save_iterates_step` correctly (bug in `CallbackStore` that is now fixed in ODL master, but not in the latest stable release yet).