### PR TITLE
Dev

### DIFF
--- a/dival/datasets/lodopab_dataset.py
+++ b/dival/datasets/lodopab_dataset.py
@@ -325,8 +325,7 @@ class LoDoPaBDataset(Dataset):
             The ray transform that corresponds to the noiseless map from
             362 x 362 images to the ``-log`` of their projections (sinograms).
         """
-        return odl.tomo.RayTransform(self.space[1], self.geometry,
-                                     range=self.space[0], **kwargs)
+        return odl.tomo.RayTransform(self.space[1], self.geometry, **kwargs)
 
     def get_sample(self, index, part='train', out=None):
         """

--- a/dival/version.py
+++ b/dival/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.4.5'
+__version__ = '0.4.6'


### PR DESCRIPTION
fix: remove unnecessary range specification in `LoDoPaBDataset.get_ray_trafo` that fails for new odl master