### PR TITLE
Dev

### DIFF
--- a/dival/reconstructors/dip_ct_reconstructor.py
+++ b/dival/reconstructors/dip_ct_reconstructor.py
@@ -128,7 +128,7 @@ class DeepImagePriorCTReconstructor(IterativeReconstructor):
 
         self.optimizer = Adam(self.model.parameters(), lr=self.lr)
 
-        y_delta = torch.tensor(observation.asarray(), dtype=torch.float32)
+        y_delta = torch.tensor(np.asarray(observation), dtype=torch.float32)
         y_delta = y_delta.view(1, 1, *y_delta.shape)
         y_delta = y_delta.to(device)
 

--- a/dival/reconstructors/fbpunet_reconstructor.py
+++ b/dival/reconstructors/fbpunet_reconstructor.py
@@ -92,7 +92,7 @@ class FBPUNetReconstructor(StandardLearnedReconstructor):
                  'by setting the attribute '
                  '``dataset.fbp_dataset = get_cached_fbp_dataset(...)``.')
             fbp_dataset = FBPDataset(
-                dataset, self.op, filter_type=self.filter_type,
+                dataset, self.non_normed_op, filter_type=self.filter_type,
                 frequency_scaling=self.frequency_scaling)
 
         if not fbp_dataset.supports_random_access():

--- a/dival/reconstructors/networks/unet.py
+++ b/dival/reconstructors/networks/unet.py
@@ -114,7 +114,6 @@ class UpBlock(nn.Module):
                 nn.LeakyReLU(0.2, inplace=True))
         else:
             self.conv = nn.Sequential(
-                nn.BatchNorm2d(in_ch + skip_ch),
                 nn.Conv2d(in_ch + skip_ch, out_ch, kernel_size, stride=1,
                           padding=to_pad),
                 nn.LeakyReLU(0.2, inplace=True),

--- a/dival/reconstructors/networks/unet.py
+++ b/dival/reconstructors/networks/unet.py
@@ -22,7 +22,7 @@ class UNet(nn.Module):
         self.use_sigmoid = use_sigmoid
         self.down = nn.ModuleList()
         self.up = nn.ModuleList()
-        self.inc = InBlock(in_ch, channels[0])
+        self.inc = InBlock(in_ch, channels[0], use_norm=use_norm)
         for i in range(1, self.scales):
             self.down.append(DownBlock(in_ch=channels[i - 1],
                                        out_ch=channels[i],

--- a/dival/reconstructors/standard_learned_reconstructor.py
+++ b/dival/reconstructors/standard_learned_reconstructor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 try:
     import torch
-except ModuleNotFoundError:
+except ImportError:
     raise ImportError('missing PyTorch')
 
 import os

--- a/dival/util/download.py
+++ b/dival/util/download.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
 import requests
+from math import ceil
 import tqdm
 import hashlib
 
 
-def download_file(url, filename=False, chunk_size=1024, verbose=False,
+def download_file(url, filename=None, chunk_size=1024, verbose=False,
                   md5sum=True):
     """
     Download file with progressbar.
@@ -24,10 +25,13 @@ def download_file(url, filename=False, chunk_size=1024, verbose=False,
         given by the last part of `url`.
     chunk_size : int, optional
         Number of bytes in a chunk.
+        Default: `1024`
     verbose : bool, optional
         Whether to print additional information.
+        Default: `False`
     md5sum : bool, optional
         Whether to compute and return the MD5 checksum (hex-digest).
+        Default: `True`
 
     Returns
     -------
@@ -41,22 +45,52 @@ def download_file(url, filename=False, chunk_size=1024, verbose=False,
     r = requests.get(url, stream=True)
     file_size = int(r.headers['Content-Length'])
     chunk = 1
-    num_bars = int(file_size / chunk_size)
+    num_chunks = ceil(file_size / chunk_size)
     if verbose:
-        print(dict(file_size=file_size))
-        print(dict(num_bars=num_bars))
+        print("downloading {:d} bytes".format(file_size))
 
     if md5sum:
         hash_md5 = hashlib.md5()
 
     with open(local_filename, 'wb') as fp:
         for chunk in tqdm.tqdm(r.iter_content(chunk_size=chunk_size),
-                               total=num_bars,
+                               total=num_chunks,
                                unit='chunks',
                                desc=local_filename,
                                leave=True):
-            fp.write(chunk)
-            if md5sum:
-                hash_md5.update(chunk)
+            if chunk:
+                fp.write(chunk)
+                if md5sum:
+                    hash_md5.update(chunk)
     if md5sum:
         return hash_md5.hexdigest()
+
+
+def compute_md5sum(filename, show_pbar=True):
+    """
+    Compute MD5 checksum of an existing file.
+
+    Parameters
+    ----------
+    filename : str
+        Filename including path.
+    show_pbar : str
+        Show tqdm progress bar.
+        Default: `True`
+
+    Returns
+    -------
+    md5sum : str
+        Hex-digest of the MD5 hash.
+    """
+    CHUNK_SIZE = 1024
+    hash_md5 = hashlib.md5()
+    file_size = os.stat(filename).st_size
+    num_chunks = ceil(file_size / CHUNK_SIZE)
+    with open(filename, 'rb') as fp:
+        for _ in tqdm.tqdm(range(num_chunks), unit='chunks', desc='md5sum',
+                           disable=not show_pbar):
+            chunk = fp.read(CHUNK_SIZE)
+            if chunk is not None:
+                hash_md5.update(chunk)
+    return hash_md5.hexdigest()

--- a/dival/util/torch_utility.py
+++ b/dival/util/torch_utility.py
@@ -1,5 +1,215 @@
-"""Provides utilities related to PyTorch."""
+"""
+Provides utilities related to PyTorch.
+
+The classes and functions
+
+    :class:`TorchRayTrafoParallel2DModule`
+    :class:`TorchRayTrafoParallel2DAdjointModule`
+    :func:`get_torch_ray_trafo_parallel_2d`
+    :func:`get_torch_ray_trafo_parallel_2d_adjoint`.
+
+in this module rely on the
+`tomosipo <https://github.com/ahendriksen/tomosipo>`_ library and experimental
+astra features available in version 1.9.9.dev4 using CUDA.
+In order to instantiate or call these classes and functions, all of these
+requirements need to be fulfilled, otherwise an :class:`ImportError` is raised.
+"""
 import torch
+try:
+    import tomosipo as ts
+except ImportError:
+    TOMOSIPO_AVAILABLE = False
+    MISSING_TOMOSIPO_MESSAGE = (
+        'Missing optional dependency \'tomosipo\'. The latest development '
+        'version can be installed via '
+        '`pip install git+https://github.com/ahendriksen/tomosipo@develop`')
+else:
+    TOMOSIPO_AVAILABLE = True
+    from tomosipo.odl import (
+        from_odl, parallel_2d_to_3d_geometry, discretized_space_2d_to_3d)
+    from tomosipo.torch_support import to_autograd
+from odl.tomo.backends.astra_cuda import astra_cuda_bp_scaling_factor
+try:
+    import astra
+except ImportError:
+    ASTRA_AVAILABLE = False
+else:
+    ASTRA_AVAILABLE = True
+
+class TorchRayTrafoParallel2DModule(torch.nn.Module):
+    """
+    Torch module applying a 2D parallel-beam ray transform using tomosipo that
+    calls the direct forward projection routine of astra, which avoids copying
+    between GPU and CPU (available in 1.9.9.dev4).
+
+    All 2D transforms are computed using a single 3D transform.
+    To this end the used tomosipo operator is renewed in :meth:`forward`
+    everytime the product of batch and channel dimensions of the current batch
+    differs compared to the previous batch, or compared to the value of
+    `init_z_shape` specified to :meth:`init` for the first batch.
+    """
+    def __init__(self, ray_trafo, init_z_shape=1):
+        """
+        Parameters
+        ----------
+        ray_trafo : :class:`odl.tomo.RayTransform`
+            Ray transform
+        init_z_shape : int, optional
+            Initial guess for the number of 2D transforms per batch, i.e. the
+            product of batch and channel dimensions.
+        """
+        if not TOMOSIPO_AVAILABLE:
+            raise ImportError(MISSING_TOMOSIPO_MESSAGE)
+        if not ASTRA_AVAILABLE:
+            raise RuntimeError('Astra is not available.')
+        if not astra.use_cuda():
+            raise RuntimeError('Astra is not able to use CUDA.')
+        super().__init__()
+        self.ray_trafo = ray_trafo
+        self._construct_operator(init_z_shape)
+
+    def _construct_operator(self, z_shape):
+        self.torch_ray_trafo = (
+            get_torch_ray_trafo_parallel_2d(self.ray_trafo, z_shape=z_shape))
+        self._z_shape = z_shape
+
+    def forward(self, x):
+        z_shape = x.shape[0] * x.shape[1]
+        if self._z_shape != z_shape:
+            self._construct_operator(z_shape)
+        x = x.view(1, z_shape, *x.shape[2:])
+        x = self.torch_ray_trafo(x)
+        x = x.view(z_shape, 1, *x.shape[2:])
+        return x
+
+class TorchRayTrafoParallel2DAdjointModule(torch.nn.Module):
+    """
+    Torch module applying the adjoint of a 2D parallel-beam ray transform
+    using tomosipo that calls the direct backward projection routine of astra,
+    which avoids copying between GPU and CPU (available in 1.9.9.dev4).
+
+    All 2D transforms are computed using a single 3D transform.
+    To this end the used tomosipo operator is renewed in :meth:`forward`
+    everytime the product of batch and channel dimensions of the current batch
+    differs compared to the previous batch, or compared to the value of
+    `init_z_shape` specified to :meth:`init` for the first batch.
+    """
+    def __init__(self, ray_trafo, init_z_shape=1):
+        """
+        Parameters
+        ----------
+        ray_trafo : :class:`odl.tomo.RayTransform`
+            Ray transform
+        init_z_shape : int, optional
+            Initial guess for the number of 2D transforms per batch, i.e. the
+            product of batch and channel dimensions.
+        """
+        if not TOMOSIPO_AVAILABLE:
+            raise ImportError(MISSING_TOMOSIPO_MESSAGE)
+        if not ASTRA_AVAILABLE:
+            raise RuntimeError('Astra is not available.')
+        if not astra.use_cuda():
+            raise RuntimeError('Astra is not able to use CUDA.')
+        super().__init__()
+        self.ray_trafo = ray_trafo
+        self._construct_operator(init_z_shape)
+
+    def _construct_operator(self, z_shape):
+        self.torch_ray_trafo_adjoint = (
+            get_torch_ray_trafo_parallel_2d_adjoint(self.ray_trafo,
+                                                    z_shape=z_shape))
+        self._z_shape = z_shape
+
+    def forward(self, x):
+        z_shape = x.shape[0] * x.shape[1]
+        if self._z_shape != z_shape:
+            self._construct_operator(z_shape)
+        x = x.view(1, z_shape, *x.shape[2:])
+        x = self.torch_ray_trafo_adjoint(x)
+        x = x.view(z_shape, 1, *x.shape[2:])
+        return x
+
+def get_torch_ray_trafo_parallel_2d(ray_trafo, z_shape=1):
+    """
+    Create a torch autograd-enabled function from a 2D parallel-beam
+    :class:`odl.tomo.RayTransform` using tomosipo that calls the direct
+    forward projection routine of astra, which avoids copying between GPU and
+    CPU (available in 1.9.9.dev4).
+
+    Parameters
+    ----------
+    ray_trafo : :class:`odl.tomo.RayTransform`
+        Ray transform
+    z_shape : int, optional
+        Channel dimension.
+        Default: ``1``.
+
+    Returns
+    -------
+    torch_ray_trafo : callable
+        Torch autograd-enabled function applying the parallel-beam forward
+        projection.
+        Input and output have a trivial leading batch dimension and a channel
+        dimension specified by `z_shape` (default ``1``), i.e. the
+        input shape is ``(1, z_shape) + ray_trafo.domain.shape`` and the
+        output shape is ``(1, z_shape) + ray_trafo.range.shape``.
+    """
+    if not TOMOSIPO_AVAILABLE:
+        raise ImportError(MISSING_TOMOSIPO_MESSAGE)
+    if not ASTRA_AVAILABLE:
+        raise RuntimeError('Astra is not available.')
+    if not astra.use_cuda():
+        raise RuntimeError('Astra is not able to use CUDA.')
+    vg = from_odl(discretized_space_2d_to_3d(ray_trafo.domain,
+                                             z_shape=z_shape))
+    pg = from_odl(parallel_2d_to_3d_geometry(ray_trafo.geometry,
+                                             det_z_shape=z_shape))
+    ts_op = ts.operator(vg, pg)
+    torch_ray_trafo = to_autograd(ts_op)
+    return torch_ray_trafo
+
+def get_torch_ray_trafo_parallel_2d_adjoint(ray_trafo, z_shape=1):
+    """
+    Create a torch autograd-enabled function from a 2D parallel-beam
+    :class:`odl.tomo.RayTransform` using tomosipo that calls the direct
+    backward projection routine of astra, which avoids copying between GPU and
+    CPU (available in 1.9.9.dev4).
+
+    Parameters
+    ----------
+    ray_trafo : :class:`odl.tomo.RayTransform`
+        Ray transform
+    z_shape : int, optional
+        Batch dimension.
+        Default: ``1``.
+
+    Returns
+    -------
+    torch_ray_trafo_adjoint : callable
+        Torch autograd-enabled function applying the parallel-beam backward
+        projection.
+        Input and output have a trivial leading batch dimension and a channel
+        dimension specified by `z_shape` (default ``1``), i.e. the
+        input shape is ``(1, z_shape) + ray_trafo.range.shape`` and the
+        output shape is ``(1, z_shape) + ray_trafo.domain.shape``.
+    """
+    if not TOMOSIPO_AVAILABLE:
+        raise ImportError(MISSING_TOMOSIPO_MESSAGE)
+    if not ASTRA_AVAILABLE:
+        raise RuntimeError('Astra is not available.')
+    if not astra.use_cuda():
+        raise RuntimeError('Astra is not able to use CUDA.')
+    vg = from_odl(discretized_space_2d_to_3d(ray_trafo.domain,
+                                             z_shape=z_shape))
+    pg = from_odl(parallel_2d_to_3d_geometry(ray_trafo.geometry,
+                                             det_z_shape=z_shape))
+    ts_op = ts.operator(vg, pg)
+    torch_ray_trafo_adjoint_ts = to_autograd(ts_op.T)
+    scaling_factor = astra_cuda_bp_scaling_factor(
+        ray_trafo.range, ray_trafo.domain, ray_trafo.geometry)
+    def torch_ray_trafo_adjoint(y):
+        return scaling_factor * torch_ray_trafo_adjoint_ts(y)
+    return torch_ray_trafo_adjoint
 
 def load_state_dict_convert_data_parallel(model, state_dict):
     """

--- a/dival/util/torch_utility.py
+++ b/dival/util/torch_utility.py
@@ -1,0 +1,73 @@
+"""Provides utilities related to PyTorch."""
+import torch
+
+def load_state_dict_convert_data_parallel(model, state_dict):
+    """
+    Load a state dict into a model, while automatically converting the weight
+    names if :attr:`model` is a :class:`nn.DataParallel`-model but the stored
+    state dict stems from a non-data-parallel model, or vice versa.
+
+    Parameters
+    ----------
+    model : nn.Module
+        Torch model that should load the state dict.
+    state_dict : dict
+        Torch state dict
+
+    Raises
+    ------
+    RuntimeError
+        If there are missing or unexpected keys in the state dict.
+        This error is not raised when conversion of the weight names succeeds.
+    """
+    missing_keys, unexpected_keys = model.load_state_dict(
+        state_dict, strict=False)
+    if missing_keys or unexpected_keys:
+        # since directly loading failed, assume now that state_dict's
+        # keys are named in the other way compared to type(model)
+        if isinstance(model, torch.nn.DataParallel):
+            state_dict = {('module.' + k): v
+                          for k, v in state_dict.items()}
+            missing_keys2, unexpected_keys2 = (
+                model.load_state_dict(state_dict, strict=False))
+            if missing_keys2 or unexpected_keys2:
+                if len(missing_keys2) < len(missing_keys):
+                    raise RuntimeError(
+                        'Failed to load learned weights. Missing keys (in '
+                        'case of prefixing with \'module.\', which lead to '
+                        'fewer missing keys):\n{}'
+                        .format(', '.join(
+                            ('"{}"'.format(k) for k in missing_keys2))))
+                else:
+                    raise RuntimeError(
+                        'Failed to load learned weights (also when trying '
+                        'with additional \'module.\' prefix). Missing '
+                        'keys:\n{}'
+                        .format(', '.join(
+                            ('"{}"'.format(k) for k in missing_keys))))
+        else:
+            if all(k.startswith('module.') for k in state_dict.keys()):
+                state_dict = {k[len('module.'):]: v
+                              for k, v in state_dict.items()}
+                missing_keys2, unexpected_keys2 = (
+                    model.load_state_dict(state_dict,
+                                               strict=False))
+                if missing_keys2 or unexpected_keys2:
+                    if len(missing_keys2) < len(missing_keys):
+                        raise RuntimeError(
+                            'Failed to load learned weights. Missing keys (in '
+                            'case of removing \'module.\' prefix, which lead '
+                            'to fewer missing keys):\n{}'
+                            .format(', '.join(
+                                ('"{}"'.format(k) for k in missing_keys2))))
+                    else:
+                        raise RuntimeError(
+                            'Failed to load learned weights (also when '
+                            'removing \'module.\' prefix). Missing keys:\n{}'
+                            .format(', '.join(
+                                ('"{}"'.format(k) for k in missing_keys))))
+            else:
+                raise RuntimeError(
+                    'Failed to load learned weights. Missing keys:\n{}'
+                    .format(', '.join(
+                        ('"{}"'.format(k) for k in missing_keys))))

--- a/dival/util/zenodo_download.py
+++ b/dival/util/zenodo_download.py
@@ -2,12 +2,15 @@
 import os
 import requests
 from dival.util.input import input_yes_no
-from dival.util.download import download_file
+from dival.util.download import download_file, compute_md5sum
 
 
-def download_zenodo_record(record_id, base_path='', md5sum_check=True):
+def download_zenodo_record(record_id, base_path='', md5sum_check=True,
+                           auto_yes=False):
     """
     Download a zenodo record.
+    Unfortunately, downloads cannot be resumed, so this method is only
+    recommended for stable internet connections.
 
     Parameters
     ----------
@@ -17,6 +20,15 @@ def download_zenodo_record(record_id, base_path='', md5sum_check=True):
         Path to store the downloaded files in. Default is the current folder.
     md5sum_check : bool, optional
         Whether to check the MD5 sum of each downloaded file.
+        Default: `True`
+    auto_yes : bool, optional
+        Whether to answer user input questions with "y" by default.
+        User input questions are:
+        If ``md5sum_check=True``, in case of a checksum mismatch: whether to
+        retry downloading.
+        If ``md5sum_check=False``, in case of an existing file of correct size:
+        whether to re-download.
+        Default: `False`
 
     Returns
     -------
@@ -30,21 +42,56 @@ def download_zenodo_record(record_id, base_path='', md5sum_check=True):
     for i, f in enumerate(files):
         url = f['links']['self']
         filename = f['key']
-        size_kb = f['size'] / 1000
+        path = os.path.join(base_path, filename)
+        size = f['size']
+        size_kb = size / 1000
         checksum = f['checksum']
+        try:
+            size_existing = os.stat(path).st_size
+        except OSError:
+            size_existing = -1
+        if size_existing == size:
+            if md5sum_check:
+                print("File {:d}/{:d}, '{}', {}KB already exists with correct "
+                      "size. Will check md5 sum now.".format(
+                          i+1, len(files), filename, size_kb))
+                md5sum_existing = compute_md5sum(path)
+                md5sum_matches = (md5sum_existing == checksum.split(':')[1])
+                if md5sum_matches:
+                    print("skipping file {}, md5 checksum matches".format(
+                        filename))
+                    continue
+                else:
+                    print("existing file {} will be overwritten, md5 checksum "
+                          "does not match".format(filename))
+            else:
+                print("File {:d}/{:d}, '{}', {}KB already exists with correct "
+                      "size. Re-download this file? (y)/n".format(
+                          i+1, len(files), filename, size_kb))
+                if auto_yes:
+                    print("y")
+                    download = True
+                else:
+                    download = input_yes_no()
+                if not download:
+                    print("skipping existing file {}".format(filename))
+                    continue
         print("downloading file {:d}/{:d}: '{}', {}KB".format(
             i+1, len(files), filename, size_kb))
         if md5sum_check:
             retry = True
             md5sum_matches = False
             while retry and not md5sum_matches:
-                md5sum = download_file(url, os.path.join(base_path, filename),
-                                       md5sum=True)
+                md5sum = download_file(url, path, md5sum=True)
                 md5sum_matches = (md5sum == checksum.split(':')[1])
                 if not md5sum_matches:
                     print("md5 checksum does not match for file '{}'. Retry "
                           "downloading? (y)/n".format(filename))
-                    retry = input_yes_no()
+                    if auto_yes:
+                        print("y")
+                        retry = True
+                    else:
+                        retry = input_yes_no()
             if not md5sum_matches:
                 success = False
                 print('record download aborted')
@@ -52,3 +99,4 @@ def download_zenodo_record(record_id, base_path='', md5sum_check=True):
         else:
             download_file(url, os.path.join(base_path, filename), md5sum=False)
     return success
+

--- a/dival/version.py
+++ b/dival/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.5.5'
+__version__ = '0.5.6'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(name='dival',
           'packaging'
       ],
       extras_require={
-          'torch_learned_reconstructors': ['torch']
+          'torch_learned_reconstructors': ['torch'],
+          'direct_gpu_parallel_beam': ['tomosipo']
       },
       include_package_data=True,
       zip_safe=False)

--- a/test/test_torch_utility.py
+++ b/test/test_torch_utility.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+import unittest
+from dival.util.torch_utility import load_state_dict_convert_data_parallel
+try:
+    import torch
+    TORCH_AVAILABLE = True
+except ModuleNotFoundError:
+    TORCH_AVAILABLE = False
+
+@unittest.skipUnless(TORCH_AVAILABLE, 'PyTorch not available')
+class TestLoadStateDictConvertDataParallel(unittest.TestCase):
+    def setUp(self):
+        self.model = torch.nn.Sequential(
+            torch.nn.Conv2d(1, 5, 3),
+            torch.nn.Conv2d(5, 1, 3))
+        self.model_parallel = torch.nn.DataParallel(self.model)
+
+    def test(self):
+        state_dict = self.model.state_dict()
+        state_dict_parallel = self.model_parallel.state_dict()
+        try:
+            load_state_dict_convert_data_parallel(self.model,
+                                                  state_dict)
+        except RuntimeError:
+            self.fail()
+        try:
+            load_state_dict_convert_data_parallel(self.model,
+                                                  state_dict_parallel)
+        except RuntimeError:
+            self.fail()
+        try:
+            load_state_dict_convert_data_parallel(self.model_parallel,
+                                                  state_dict)
+        except RuntimeError:
+            self.fail()
+        try:
+            load_state_dict_convert_data_parallel(self.model_parallel,
+                                                  state_dict_parallel)
+        except RuntimeError:
+            self.fail()
+        state_dict_missing = {
+            k: v for i, (k, v) in enumerate(state_dict.items()) if i >= 1}
+        state_dict_parallel_missing = {
+            k: v for i, (k, v) in enumerate(state_dict_parallel.items())
+            if i >= 1}
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model, state_dict_missing)
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model, state_dict_parallel_missing)
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model_parallel, state_dict_missing)
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model_parallel, state_dict_parallel_missing)
+        state_dict_unexpected = {
+            '{}_unexpected'.format(k): v for k, v in state_dict.items()}
+        state_dict_parallel_unexpected = {
+            '{}_unexpected'.format(k): v for k, v in
+            state_dict_parallel.items()}
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model, state_dict_unexpected)
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model, state_dict_parallel_unexpected)
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model_parallel, state_dict_unexpected)
+        with self.assertRaises(RuntimeError):
+            load_state_dict_convert_data_parallel(
+                self.model_parallel, state_dict_parallel_unexpected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_torch_utility.py
+++ b/test/test_torch_utility.py
@@ -2,11 +2,145 @@
 import unittest
 try:
     import torch
-    TORCH_AVAILABLE = True
-except ModuleNotFoundError:
+except ImportError:
     TORCH_AVAILABLE = False
 else:
-    from dival.util.torch_utility import load_state_dict_convert_data_parallel
+    TORCH_AVAILABLE = True
+    from dival.util.torch_utility import (
+        load_state_dict_convert_data_parallel, TOMOSIPO_AVAILABLE,
+        TorchRayTrafoParallel2DModule, TorchRayTrafoParallel2DAdjointModule)
+import numpy as np
+from dival import get_standard_dataset
+try:
+    import astra
+except ImportError:
+    ASTRA_CUDA_AVAILABLE = False
+else:
+    ASTRA_CUDA_AVAILABLE = astra.use_cuda()
+
+@unittest.skipUnless(
+    TORCH_AVAILABLE and TOMOSIPO_AVAILABLE and ASTRA_CUDA_AVAILABLE,
+    'PyTorch or tomosipo or ASTRA+CUDA not available')
+class TestTorchRayTrafoParallel2DModule(unittest.TestCase):
+    def test(self):
+        dataset = get_standard_dataset('ellipses', fixed_seeds=True,
+                                       impl='astra_cuda')
+        ray_trafo = dataset.get_ray_trafo(impl='astra_cuda')
+        module = TorchRayTrafoParallel2DModule(ray_trafo)
+        for batch_size, channels in [(1, 3),
+                                     (5, 1),
+                                     (2, 3)]:
+            test_data = dataset.get_data_pairs(part='train',
+                                               n=batch_size * channels)
+            torch_in = (torch.from_numpy(np.asarray(test_data.ground_truth))
+                        .view(batch_size, channels, *dataset.shape[1]))
+            torch_out = module(torch_in).view(-1, *dataset.shape[0])
+            for i, odl_in in enumerate(test_data.ground_truth):
+                odl_out = ray_trafo(odl_in)
+                self.assertTrue(np.allclose(
+                    torch_out[i].detach().cpu().numpy(), odl_out, rtol=1.e-2))
+
+    def testGradient(self):
+        dataset = get_standard_dataset('ellipses', fixed_seeds=True,
+                                       impl='astra_cuda')
+        ray_trafo = dataset.get_ray_trafo(impl='astra_cuda')
+        module = TorchRayTrafoParallel2DModule(ray_trafo)
+        batch_size, channels = 2, 3
+        torch_in_ = torch.ones(
+            (batch_size * channels,) + dataset.shape[1],
+            requires_grad=True)
+        torch_in = torch_in_.view(batch_size, channels, *dataset.shape[1])
+        torch_out = module(torch_in).view(-1, *dataset.shape[0])
+        for i in range(batch_size * channels):
+            for j in range(0, dataset.shape[0][0], 3):  # angle
+                for k in range(0, dataset.shape[0][1], 12):  # detector pos
+                    odl_value_in = np.zeros(dataset.shape[0])
+                    odl_value_in[j, k] = 1.
+                    odl_grad = ray_trafo.adjoint(odl_value_in)
+                    torch_in_.grad = None
+                    torch_out[i, j, k].backward(retain_graph=True)
+                    torch_grad_np = (
+                        torch_in_.grad[i].detach().cpu().numpy())
+                    # very rough check for maximum error
+                    self.assertTrue(np.allclose(torch_grad_np, odl_grad,
+                        rtol=1.))
+                    non_zero = np.nonzero(np.asarray(odl_grad))
+                    if np.any(odl_grad):  # there seem to be cases where
+                                          # a pixel has no influence on the
+                                          # gradient
+                        # tighter check for mean error
+                        self.assertLess(np.mean(np.abs(
+                            torch_grad_np[non_zero] - odl_grad[non_zero])
+                            / np.abs(odl_grad[non_zero])), 1e-3)
+
+@unittest.skipUnless(
+    TORCH_AVAILABLE and TOMOSIPO_AVAILABLE and ASTRA_CUDA_AVAILABLE,
+    'PyTorch or tomosipo or ASTRA+CUDA not available')
+class TestTorchRayTrafoParallel2DAdjointModule(unittest.TestCase):
+    def test(self):
+        dataset = get_standard_dataset('ellipses', fixed_seeds=True,
+                                       impl='astra_cuda')
+        ray_trafo = dataset.get_ray_trafo(impl='astra_cuda')
+        module = TorchRayTrafoParallel2DAdjointModule(ray_trafo)
+        for batch_size, channels in [(1, 3),
+                                     (5, 1),
+                                     (2, 3)]:
+            test_data = dataset.get_data_pairs(part='train',
+                                               n=batch_size * channels)
+            torch_in = (torch.from_numpy(np.asarray(test_data.observations))
+                        .view(batch_size, channels, *dataset.shape[0]))
+            torch_out = module(torch_in).view(-1, *dataset.shape[1])
+            for i, odl_in in enumerate(test_data.observations):
+                odl_out = ray_trafo.adjoint(odl_in)
+                self.assertTrue(np.allclose(
+                    torch_out[i].detach().cpu().numpy(), odl_out, rtol=1.e-4))
+
+    def testGradient(self):
+        dataset = get_standard_dataset('ellipses', fixed_seeds=True,
+                                       impl='astra_cuda')
+        ray_trafo = dataset.get_ray_trafo(impl='astra_cuda')
+        module = TorchRayTrafoParallel2DAdjointModule(ray_trafo)
+        batch_size, channels = 2, 2
+        torch_in_ = torch.ones(
+            (batch_size * channels,) + dataset.shape[0],
+            requires_grad=True)
+        torch_in = torch_in_.view(batch_size, channels, *dataset.shape[0])
+        torch_out = module(torch_in).view(-1, *dataset.shape[1])
+        for i in range(batch_size * channels):
+            for j in range(0, dataset.shape[1][0], 9):  # x
+                for k in range(0, dataset.shape[1][1], 9):  # y
+                    odl_value_in = np.zeros(dataset.shape[1])
+                    odl_value_in[j, k] = 1.
+                    odl_grad = ray_trafo.adjoint.adjoint(odl_value_in)
+                    torch_in_.grad = None
+                    torch_out[i, j, k].backward(retain_graph=True)
+                    torch_grad_np = (
+                        torch_in_.grad[i].detach().cpu().numpy())
+                    # very rough check for maximum error
+                    self.assertTrue(np.allclose(torch_grad_np, odl_grad,
+                        rtol=1.))
+                    non_zero = np.nonzero(np.asarray(odl_grad))
+                    if np.any(odl_grad):  # there seem to be cases where
+                                          # a pixel has no influence on the
+                                          # gradient
+                        # tighter check for mean error
+                        self.assertLess(np.mean(np.abs(
+                            torch_grad_np[non_zero] - odl_grad[non_zero])
+                            / np.abs(odl_grad[non_zero])), 1e-2)
+
+@unittest.skipUnless(
+    TORCH_AVAILABLE and TOMOSIPO_AVAILABLE and ASTRA_CUDA_AVAILABLE,
+    'PyTorch or tomosipo or ASTRA+CUDA not available')
+class TestGetTorchRayTrafoParallel2d(unittest.TestCase):
+    def test(self):
+        pass
+
+@unittest.skipUnless(
+    TORCH_AVAILABLE and TOMOSIPO_AVAILABLE and ASTRA_CUDA_AVAILABLE,
+    'PyTorch or tomosipo or ASTRA+CUDA not available')
+class TestGetTorchRayTrafoParallel2dAdjoint(unittest.TestCase):
+    def test(self):
+        pass
 
 @unittest.skipUnless(TORCH_AVAILABLE, 'PyTorch not available')
 class TestLoadStateDictConvertDataParallel(unittest.TestCase):

--- a/test/test_torch_utility.py
+++ b/test/test_torch_utility.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import unittest
-from dival.util.torch_utility import load_state_dict_convert_data_parallel
 try:
     import torch
     TORCH_AVAILABLE = True
 except ModuleNotFoundError:
     TORCH_AVAILABLE = False
+else:
+    from dival.util.torch_utility import load_state_dict_convert_data_parallel
 
 @unittest.skipUnless(TORCH_AVAILABLE, 'PyTorch not available')
 class TestLoadStateDictConvertDataParallel(unittest.TestCase):


### PR DESCRIPTION
* fixes in TVAdamReconstructor, FBPUNetReconstructor and UNet (affected non-default cases only)
* reduce RAM usage during cache file generation
* check for existing files in zenodo_download
* add torch utilities:
    * Modules computing batches of 2D parallel beam transforms by using experimental direct methods of astra via tomosipo
    * automatic conversion of [non-]DataParallel weights when loading a state dict
