### PR TITLE
improve Dataset.create_torch_dataset and StandandLearnedReconstructor, enable more pickling

### DIFF
--- a/dival/datasets/cached_dataset.py
+++ b/dival/datasets/cached_dataset.py
@@ -208,8 +208,11 @@ class CachedDataset(Dataset):
             out_dataset = tuple(
                 (out_orig if cache is None else False
                  for out_orig, cache in zip(out, self.data[part])))
-            from_dataset = self.dataset.get_sample(index, part=part,
-                                                   out=out_dataset)
+            from_dataset = (
+                self.dataset.get_sample(index, part=part, out=out_dataset)
+                if any(o_d is not False for o_d in out_dataset) else
+                (None,) * self.num_elements_per_sample)  # avoids
+                                 # NotImplementedError if all values are cached
             sample = []
             for from_d, cache, out_, space in zip(
                     from_dataset, self.data[part], out, self.space):
@@ -246,8 +249,11 @@ class CachedDataset(Dataset):
             out_dataset = tuple(
                 (out_orig if cache is None else False
                  for out_orig, cache in zip(out, self.data[part])))
-            from_dataset = self.dataset.get_samples(key, part=part,
-                                                    out=out_dataset)
+            from_dataset = (
+                self.dataset.get_samples(key, part=part, out=out_dataset)
+                if any(o_d is not False for o_d in out_dataset) else
+                (None,) * self.num_elements_per_sample)  # avoids
+                                 # NotImplementedError if all values are cached
             samples = []
             for from_d, cache, out_ in zip(from_dataset, self.data[part], out):
                 if cache is None:

--- a/dival/examples/ct_train_fbpunet_data_augmentation.py
+++ b/dival/examples/ct_train_fbpunet_data_augmentation.py
@@ -1,0 +1,91 @@
+"""
+Train FBPUNetReconstructor with data augmentation on 'lodopab'.
+"""
+import numpy as np
+from dival import get_standard_dataset
+from dival.measure import PSNR
+from dival.reconstructors.fbpunet_reconstructor import FBPUNetReconstructor
+from dival.datasets.fbp_dataset import (
+    generate_fbp_cache_files, get_cached_fbp_dataset)
+from dival.reference_reconstructors import (
+    check_for_params, download_params, get_hyper_params_path)
+from dival.util.plot import plot_images
+import torch
+
+IMPL = 'astra_cuda'
+
+LOG_DIR = './logs/lodopab_fbpunet_data_augmentation'
+SAVE_BEST_LEARNED_PARAMS_PATH = './params/lodopab_fbpunet_data_augmentation'
+
+CACHE_FILES = {
+    'train':
+        ('/localdata/dival_dataset_caches/cache_train_lodopab_fbp.npy', None),
+    'validation':
+        ('/localdata/dival_dataset_caches/cache_validation_lodopab_fbp.npy', None)}
+
+dataset = get_standard_dataset('lodopab', impl=IMPL)
+ray_trafo = dataset.get_ray_trafo(impl=IMPL)
+test_data = dataset.get_data_pairs('test', 100)
+
+
+def random_flip_rotate_transform(sample):
+    fbp, gt = sample
+    choice = torch.randint(8, (1,))[0]
+    if choice % 4 == 1:
+        fbp = torch.flip(fbp, (1,))
+        gt = torch.flip(gt, (1,))
+    elif choice % 4 == 2:
+        fbp = torch.flip(fbp, (2,))
+        gt = torch.flip(gt, (2,))
+    elif choice % 4 == 3:
+        fbp = torch.flip(fbp, (1, 2))
+        gt = torch.flip(gt, (1, 2))
+    if choice // 4 == 1:
+        fbp = torch.transpose(fbp, 1, 2)
+        gt = torch.transpose(gt, 1, 2)
+    return fbp, gt
+
+
+class FBPUNetDataAugmentationReconstructor(FBPUNetReconstructor):
+    def init_transform(self, dataset):
+        self._transform = random_flip_rotate_transform
+
+
+reconstructor = FBPUNetDataAugmentationReconstructor(
+    ray_trafo, log_dir=LOG_DIR,
+    save_best_learned_params_path=SAVE_BEST_LEARNED_PARAMS_PATH)
+
+#%% obtain reference hyper parameters
+if not check_for_params('fbpunet', 'lodopab', include_learned=False):
+    download_params('fbpunet', 'lodopab', include_learned=False)
+hyper_params_path = get_hyper_params_path('fbpunet', 'lodopab')
+reconstructor.load_hyper_params(hyper_params_path)
+
+#%% expose FBP cache to reconstructor by assigning `fbp_dataset` attribute
+# uncomment the next line to generate the cache files (~20 GB)
+# generate_fbp_cache_files(dataset, ray_trafo, CACHE_FILES)
+cached_fbp_dataset = get_cached_fbp_dataset(dataset, ray_trafo, CACHE_FILES)
+dataset.fbp_dataset = cached_fbp_dataset
+
+#%% train
+# reduce the batch size here if the model does not fit into GPU memory
+# reconstructor.batch_size = 16
+reconstructor.train(dataset)
+
+#%% evaluate
+recos = []
+psnrs = []
+for obs, gt in test_data:
+    reco = reconstructor.reconstruct(obs)
+    recos.append(reco)
+    psnrs.append(PSNR(reco, gt))
+
+print('mean psnr: {:f}'.format(np.mean(psnrs)))
+
+for i in range(3):
+    _, ax = plot_images([recos[i], test_data.ground_truth[i]],
+                        fig_size=(10, 4))
+    ax[0].set_xlabel('PSNR: {:.2f}'.format(psnrs[i]))
+    ax[0].set_title('FBPUNetReconstructor')
+    ax[1].set_title('ground truth')
+    ax[0].figure.suptitle('test sample {:d}'.format(i))

--- a/dival/examples/ct_train_fbpunet_ellipses_multiple_workers.py
+++ b/dival/examples/ct_train_fbpunet_ellipses_multiple_workers.py
@@ -12,7 +12,7 @@ from dival.reconstructors.fbpunet_reconstructor import FBPUNetReconstructor
 from dival.reference_reconstructors import (
     check_for_params, download_params, get_hyper_params_path)
 from dival.util.plot import plot_images
-from dival.util.torch_utility import patch_ray_trafo_for_pickling
+from dival.util.odl_utility import patch_ray_trafo_for_pickling
 
 IMPL = 'astra_cuda'
 

--- a/dival/examples/ct_train_fbpunet_ellipses_multiple_workers.py
+++ b/dival/examples/ct_train_fbpunet_ellipses_multiple_workers.py
@@ -1,0 +1,87 @@
+"""
+Train FBPUNetReconstructor on ``'ellipses'``.
+"""
+from odl.operator import OperatorComp
+from torch.multiprocessing import set_start_method, get_start_method
+import torch
+import odl
+import numpy as np
+from dival import get_standard_dataset
+from dival.measure import PSNR
+from dival.reconstructors.fbpunet_reconstructor import FBPUNetReconstructor
+from dival.reference_reconstructors import (
+    check_for_params, download_params, get_hyper_params_path)
+from dival.util.plot import plot_images
+from dival.util.torch_utility import patch_ray_trafo_for_pickling
+
+IMPL = 'astra_cuda'
+
+LOG_DIR = './logs/ellipses_fbpunet'
+SAVE_BEST_LEARNED_PARAMS_PATH = './params/ellipses_fbpunet'
+
+
+def worker_init_fn(worker_id):
+    worker_info = torch.utils.data.get_worker_info()
+    dataset = worker_info.dataset  # the dataset copy in this worker process
+    
+    # recreate forward_op
+    # (to avoid astra.data2d.py ValueError: Data object not found)
+    ray_trafo = dataset.dataset.dataset.forward_op.left
+    dataset.dataset.dataset.forward_op = OperatorComp(
+        odl.tomo.RayTransform(
+            ray_trafo.domain, ray_trafo.geometry, impl=ray_trafo.impl),
+        dataset.dataset.dataset.forward_op.right)
+
+
+if __name__ == '__main__':
+    try:
+        set_start_method('spawn')
+    except RuntimeError:
+        if get_start_method() != 'spawn':
+            raise RuntimeError(
+                'Could not set multiprocessing start method to \'spawn\'')
+
+    dataset = get_standard_dataset('ellipses',
+                                    fixed_seeds=False,
+                                    fixed_noise_seeds=False,
+                                    impl=IMPL)
+    ray_trafo = dataset.get_ray_trafo(impl=IMPL)
+    patch_ray_trafo_for_pickling(ray_trafo)
+    test_data = dataset.get_data_pairs('test', 100)
+    
+    reconstructor = FBPUNetReconstructor(
+        ray_trafo, log_dir=LOG_DIR,
+        save_best_learned_params_path=SAVE_BEST_LEARNED_PARAMS_PATH,
+        allow_multiple_workers_without_random_access=True,
+        num_data_loader_workers=2,  # more workers lead to increased VRAM usage
+        worker_init_fn=worker_init_fn,  # for recreating forward_op
+        )
+    
+    #%% obtain reference hyper parameters
+    if not check_for_params('fbpunet', 'ellipses', include_learned=False):
+        download_params('fbpunet', 'ellipses', include_learned=False)
+    hyper_params_path = get_hyper_params_path('fbpunet', 'ellipses')
+    reconstructor.load_hyper_params(hyper_params_path)
+    
+    #%% train
+    # reduce the batch size here if the model does not fit into GPU memory
+    # reconstructor.batch_size = 16
+    reconstructor.train(dataset)
+    
+    #%% evaluate
+    recos = []
+    psnrs = []
+    for obs, gt in test_data:
+        reco = reconstructor.reconstruct(obs)
+        recos.append(reco)
+        psnrs.append(PSNR(reco, gt))
+    
+    print('mean psnr: {:f}'.format(np.mean(psnrs)))
+    
+    for i in range(3):
+        _, ax = plot_images([recos[i], test_data.ground_truth[i]],
+                            fig_size=(10, 4))
+        ax[0].set_xlabel('PSNR: {:.2f}'.format(psnrs[i]))
+        ax[0].set_title('FBPUNetReconstructor')
+        ax[1].set_title('ground truth')
+        ax[0].figure.suptitle('test sample {:d}'.format(i))

--- a/dival/util/odl_utility.py
+++ b/dival/util/odl_utility.py
@@ -10,6 +10,7 @@ from odl.operator.operator import Operator
 from odl.solvers.util.callback import Callback
 from odl.util import signature_string
 import numpy as np
+from skimage.transform import resize
 
 
 def uniform_discr_element(inp, space=None):
@@ -279,3 +280,14 @@ class CallbackStoreAfter(Callback):
                    ('store_after_iters', self.store_after_iters, [])]
         inner_str = signature_string([], optargs)
         return '{}({})'.format(self.__class__.__name__, inner_str)
+
+
+class ResizeOperator(Operator):
+    def __init__(self, reco_space, space, order=1):
+        self.target_shape = space.shape
+        self.order = order
+        super().__init__(reco_space, space)
+
+    def _call(self, x, out):
+        out.assign(self.range.element(
+            resize(x, self.target_shape, order=self.order)))

--- a/dival/util/odl_utility.py
+++ b/dival/util/odl_utility.py
@@ -291,3 +291,71 @@ class ResizeOperator(Operator):
     def _call(self, x, out):
         out.assign(self.range.element(
             resize(x, self.target_shape, order=self.order)))
+
+
+class RayBackProjection(Operator):
+    """Adjoint of the discrete Ray transform between L^p spaces.
+
+    This class is copied and modified from
+    `odl <https://github.com/odlgroup/odl/blob/25ec783954a85c2294ad5b76414f8c7c3cd2785d/odl/tomo/operators/ray_trafo.py#L324>`_.
+
+    This main-scope class definition is used by
+    :func:`patch_ray_trafo_for_pickling` to make a ray transform object
+    pickleable by replacing its :attr:`_adjoint` attribute with an instance of
+    this class.
+    """
+    def __init__(self, ray_trafo, **kwargs):
+        self.ray_trafo = ray_trafo
+        super().__init__(**kwargs)
+
+    def _call(self, x, out=None, **kwargs):
+        """Backprojection.
+
+        Parameters
+        ----------
+        x : DiscretizedSpaceElement
+            A sinogram. Must be an element of
+            `RayTransform.range` (domain of `RayBackProjection`).
+        out : `RayBackProjection.domain` element, optional
+            A volume to which the result of this evaluation is
+            written.
+        **kwargs
+            Extra keyword arguments, passed on to the
+            implementation backend.
+
+        Returns
+        -------
+        DiscretizedSpaceElement
+            Result of the transform in the domain
+            of `RayProjection`.
+        """
+        return self.ray_trafo.get_impl(
+            self.ray_trafo.use_cache
+        ).call_backward(x, out, **kwargs)
+
+    @property
+    def geometry(self):
+        return self.ray_trafo.geometry
+
+    @property
+    def adjoint(self):
+        return self.ray_trafo
+
+
+def patch_ray_trafo_for_pickling(ray_trafo):
+    """
+    Make an object of type :class:`odl.tomo.operators.RayTransform` pickleable
+    by overwriting the :attr:`_adjoint` (which originally has a local class
+    type) with a :class:`dival.util.torch_utility.RayBackProjection` object.
+    This can be required for multiprocessing.
+
+    Parameters
+    ----------
+    ray_trafo : :class:`odl.tomo.operators.RayTransform`
+        The ray transform to patch for pickling.
+    """
+    kwargs = ray_trafo._extra_kwargs.copy()
+    kwargs['domain'] = ray_trafo.range
+    ray_trafo._adjoint = RayBackProjection(
+        ray_trafo, range=ray_trafo.domain, linear=True, **kwargs
+    )

--- a/dival/util/torch_utility.py
+++ b/dival/util/torch_utility.py
@@ -14,6 +14,7 @@ astra features available in version 1.9.9.dev4 using CUDA.
 In order to instantiate or call these classes and functions, all of these
 requirements need to be fulfilled, otherwise an :class:`ImportError` is raised.
 """
+import numpy as np
 import torch
 try:
     import tomosipo as ts
@@ -29,12 +30,74 @@ else:
         from_odl, parallel_2d_to_3d_geometry, discretized_space_2d_to_3d)
     from tomosipo.torch_support import to_autograd
 from odl.tomo.backends.astra_cuda import astra_cuda_bp_scaling_factor
+from odl import Operator
 try:
     import astra
 except ImportError:
     ASTRA_AVAILABLE = False
 else:
     ASTRA_AVAILABLE = True
+
+
+class RandomAccessTorchDataset(torch.utils.data.Dataset):
+    def __init__(self, dataset, part, reshape=None,
+                 transform=None):
+        self.dataset = dataset
+        self.part = part
+        self.reshape = reshape or (
+            (None,) * self.dataset.get_num_elements_per_sample())
+        self.transform = transform
+
+    def __len__(self):
+        return self.dataset.get_len(self.part)
+
+    def __getitem__(self, idx):
+        arrays = self.dataset.get_sample(idx, part=self.part)
+        mult_elem = isinstance(arrays, tuple)
+        if not mult_elem:
+            arrays = (arrays,)
+        tensors = []
+        for arr, s in zip(arrays, self.reshape):
+            t = torch.from_numpy(np.asarray(arr))
+            if s is not None:
+                t = t.view(*s)
+            tensors.append(t)
+        sample = tuple(tensors) if mult_elem else tensors[0]
+        if self.transform is not None:
+            sample = self.transform(sample)
+        return sample
+
+class GeneratorTorchDataset(torch.utils.data.IterableDataset):
+    def __init__(self, dataset, part, reshape=None,
+                 transform=None):
+        self.part = part
+        self.dataset = dataset
+        self.reshape = reshape or (
+            (None,) * dataset.get_num_elements_per_sample())
+        self.transform = transform
+
+    def __len__(self):
+        return self.dataset.get_len(self.part)
+
+    def __iter__(self):
+        return self.generate()
+
+    def generate(self):
+        for arrays in self.dataset.generator(self.part):
+            mult_elem = isinstance(arrays, tuple)
+            if not mult_elem:
+                arrays = (arrays,)
+            tensors = []
+            for arr, s in zip(arrays, self.reshape):
+                t = torch.from_numpy(np.asarray(arr))
+                if s is not None:
+                    t = t.view(*s)
+                tensors.append(t)
+            sample = tuple(tensors) if mult_elem else tensors[0]
+            if self.transform is not None:
+                sample = self.transform(sample)
+            yield sample
+
 
 class TorchRayTrafoParallel2DModule(torch.nn.Module):
     """
@@ -281,3 +344,69 @@ def load_state_dict_convert_data_parallel(model, state_dict):
                     'Failed to load learned weights. Missing keys:\n{}'
                     .format(', '.join(
                         ('"{}"'.format(k) for k in missing_keys))))
+
+class RayBackProjection(Operator):
+    """Adjoint of the discrete Ray transform between L^p spaces.
+
+    This class is copied and modified from
+    `odl <https://github.com/odlgroup/odl/blob/25ec783954a85c2294ad5b76414f8c7c3cd2785d/odl/tomo/operators/ray_trafo.py#L324>`_.
+
+    This main-scope class definition is used by
+    :func:`patch_ray_trafo_for_pickling` to make a ray transform object
+    pickleable by replacing its :attr:`_adjoint` attribute with an instance of
+    this class.
+    """
+    def __init__(self, ray_trafo, **kwargs):
+        self.ray_trafo = ray_trafo
+        super().__init__(**kwargs)
+
+    def _call(self, x, out=None, **kwargs):
+        """Backprojection.
+
+        Parameters
+        ----------
+        x : DiscretizedSpaceElement
+            A sinogram. Must be an element of
+            `RayTransform.range` (domain of `RayBackProjection`).
+        out : `RayBackProjection.domain` element, optional
+            A volume to which the result of this evaluation is
+            written.
+        **kwargs
+            Extra keyword arguments, passed on to the
+            implementation backend.
+
+        Returns
+        -------
+        DiscretizedSpaceElement
+            Result of the transform in the domain
+            of `RayProjection`.
+        """
+        return self.ray_trafo.get_impl(
+            self.ray_trafo.use_cache
+        ).call_backward(x, out, **kwargs)
+
+    @property
+    def geometry(self):
+        return self.ray_trafo.geometry
+
+    @property
+    def adjoint(self):
+        return self.ray_trafo
+
+def patch_ray_trafo_for_pickling(ray_trafo):
+    """
+    Make an object of type :class:`odl.tomo.operators.RayTransform` pickleable
+    by overwriting the :attr:`_adjoint` (which originally has a local class
+    type) with a :class:`dival.util.torch_utility.RayBackProjection` object.
+    This can be required for multiprocessing.
+
+    Parameters
+    ----------
+    ray_trafo : :class:`odl.tomo.operators.RayTransform`
+        The ray transform to patch for pickling.
+    """
+    kwargs = ray_trafo._extra_kwargs.copy()
+    kwargs['domain'] = ray_trafo.range
+    ray_trafo._adjoint = RayBackProjection(
+        ray_trafo, range=ray_trafo.domain, linear=True, **kwargs
+    )

--- a/dival/version.py
+++ b/dival/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.5.8'
+__version__ = '0.6.0'


### PR DESCRIPTION
- fix `CachedDataset` for the case of all parts being cached. It supports random access then, but previously it was broken due to still calling `self.dataset.get_sample[s]` with the out parameter being all `False`.
- improve `Dataset.create_torch_dataset`
  - add `transform` parameter
  - move the previously local torch dataset class definitions to `dival.util.torch_utility`
  - use `torch.utils.data.IterableDataset` (instead of using `torch.utils.data.Dataset` and ignoring the index) for generator-based datasets
  - fix docs
- make `'ellipses'` standard dataset pickleable and add `fixed_noise_seeds` parameter (still `True` by default, in contrast to `noise_seeds` (used for the ground truth image generation), which is `False` by default. Both (different) defaults are kept like they were).
- fix and improve `evaluation.run` implementation by avoiding to save reconstructions when run with `save_reconstructions=False`, reducing RAM usage
- add example scripts
- add option to allow multiple workers with generator-based datasets in `FBPUNetReconstructor`, remove warning about shuffling not working for generator-based datasets (for `shuffle=True`, it will raise an error due to `Dataset.create_torch_dataset` now returning a `torch.utils.data.IterableDataset`, and for `shuffle='auto'` the docs for `StandardLearnedReconstructor` describe that shuffling is not used in this case)
- improve `StandardLearnedReconstructor`
  - add possibility for a transform (data augmentation) via implementing `init_transform` in a subclass
- add `shuffle` option, defaulting to `'auto'` which depends on whether the dataset supports random access. Previously `shuffle=True` was always used, but for generator-based datasets the index was ignored, effectively disabling shuffling.
- add `dival.util.odl_utility.patch_ray_trafo_for_pickling`