### PR TITLE
Fix zenodo_download.py

### DIFF
--- a/dival/util/download.py
+++ b/dival/util/download.py
@@ -43,11 +43,14 @@ def download_file(url, filename=None, chunk_size=1024, verbose=False,
     else:
         local_filename = filename
     r = requests.get(url, stream=True)
-    file_size = int(r.headers['Content-Length'])
-    chunk = 1
-    num_chunks = ceil(file_size / chunk_size)
-    if verbose:
-        print("downloading {:d} bytes".format(file_size))
+    if r.headers.get('Transfer-Encoding', 'identity') == 'chunked':
+        num_chunks = None
+        print("downloading")
+    else:
+        file_size = int(r.headers['Content-Length'])
+        num_chunks = ceil(file_size / chunk_size)
+        if verbose:
+            print("downloading {:d} bytes".format(file_size))
 
     if md5sum:
         hash_md5 = hashlib.md5()

--- a/dival/util/zenodo_download.py
+++ b/dival/util/zenodo_download.py
@@ -40,10 +40,10 @@ def download_zenodo_record(record_id, base_path='', md5sum_check=True,
     files = r.json()['files']
     success = True
     for i, f in enumerate(files):
-        url = f['links']['self']
-        filename = f['key']
+        url = f['links']['download']
+        filename = f['filename']
         path = os.path.join(base_path, filename)
-        size = f['size']
+        size = f['filesize']
         size_kb = size / 1000
         checksum = f['checksum']
         try:
@@ -56,7 +56,7 @@ def download_zenodo_record(record_id, base_path='', md5sum_check=True,
                       "size. Will check md5 sum now.".format(
                           i+1, len(files), filename, size_kb))
                 md5sum_existing = compute_md5sum(path)
-                md5sum_matches = (md5sum_existing == checksum.split(':')[1])
+                md5sum_matches = (md5sum_existing == checksum)
                 if md5sum_matches:
                     print("skipping file {}, md5 checksum matches".format(
                         filename))
@@ -83,7 +83,7 @@ def download_zenodo_record(record_id, base_path='', md5sum_check=True,
             md5sum_matches = False
             while retry and not md5sum_matches:
                 md5sum = download_file(url, path, md5sum=True)
-                md5sum_matches = (md5sum == checksum.split(':')[1])
+                md5sum_matches = (md5sum == checksum)
                 if not md5sum_matches:
                     print("md5 checksum does not match for file '{}'. Retry "
                           "downloading? (y)/n".format(filename))


### PR DESCRIPTION
Hello @jleuschn ,

It looks like the url header key names for the lodopab-ct dataset have changed. I updated `zenodo_download.py` to be able to download the lodopab-ct dataset again.

This should fix #41.

Best,
Julian